### PR TITLE
feat: add internal option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ module.exports = ({ env }) => ({
         uploadPath: env('UPLOAD_PATH'),
         baseUrl: env('BASE_URL'),
         timeout: env('TIMEOUT'),
-        secure: env('OSS_SECURE')
+        secure: env('OSS_SECURE'),
+        internal: env.bool('OSS_INTERNAL', false),
       }
     }
   }
@@ -65,7 +66,8 @@ module.exports = ({ env }) => ({
       uploadPath: env('UPLOAD_PATH'),
       baseUrl: env('BASE_URL'),
       timeout: env('TIMEOUT'),
-      secure: env('OSS_SECURE') //default to true
+      secure: env('OSS_SECURE'), //default to true
+      internal: env.bool('OSS_INTERNAL', false),
     }
   }
 });
@@ -84,6 +86,7 @@ Property | type |  value
 **timeout** | integer | OSS upload timeout (unit: seconds)
 **secure** | boolean | will https mode be enabled for oss client
 **autoThumb** (Beta) | boolean |  **VIDEO FILES ONLY** currently only supports `.mp4` file, will generate thumbnail for the video uploaded (screenshot at `00:01` of the video, size: `480x360`)
+**internal** | boolean | access OSS with aliyun internal network or not, default is false. If your servers are running on aliyun too, you can set true to save lot of money.
 
 
 # OSS Region reference

--- a/lib/index.js
+++ b/lib/index.js
@@ -90,6 +90,7 @@ module.exports = {
       bucket: config.bucket,
       timeout: +(config.timeout * 1000),
       secure: !(config.secure === false),
+      internal: config.internal === true,
     });
 
     const upload = (file, customParams = {}) => 


### PR DESCRIPTION
feature: add `internal` option. 

When `internal` is `true` we can active the `internal` option of ali-oss, which will make `put`  extremely faster and will save a lot of money.

https://github.com/ali-sdk/ali-oss#ossoptions

> * [internal] {Boolean} access OSS with aliyun internal network or not, default is false. If your servers are running on aliyun too, you can set true to save lot of money.

https://help.aliyun.com/document_detail/39584.html

<img width="883" alt="image" src="https://github.com/hezzze/strapi-provider-upload-oss/assets/1927546/565e6d0a-daf2-4f9d-a0ab-c91713adaa96">
