### PR TITLE
fix: respect file.path in upload, delete and getFileKey

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,16 +33,18 @@ module.exports = {
     });
 
     const getFileKey = (file) => {
-      const path = file.path ? `${file.path}/` : '';
-      return `${config.uploadPath + '/' || ''}${path}${file.hash}${file.ext}`;
+      const base = config.uploadPath ? `${config.uploadPath}/` : '';
+      const subPath = file.path ? `${file.path}/` : '';
+      return `${base}${subPath}${file.hash}${file.ext}`;
     };
 
     const upload = (file, customParams = {}) =>
       new Promise((resolve, reject) => {
         // upload file on OSS bucket
-        const path = config.uploadPath ? `${config.uploadPath}/` : '';
+        const base = config.uploadPath ? `${config.uploadPath}/` : '';
+        const subPath = file.path ? `${file.path}/` : '';
         const fileName = `${file.hash}${file.ext}`;
-        const fullPath = `${path}${fileName}`;
+        const fullPath = `${base}${subPath}${fileName}`;
 
         ossClient.put(fullPath, file.stream || Buffer.from(file.buffer, 'binary'), customParams)
           .then((result) => {
@@ -87,8 +89,9 @@ module.exports = {
       delete(file, customParams = {}) {
         return new Promise((resolve, reject) => {
           // delete file on OSS bucket
-          const path = config.uploadPath ? `${config.uploadPath}/` : '';
-          const fullPath = `${path}${file.hash}${file.ext}`;
+          const base = config.uploadPath ? `${config.uploadPath}/` : '';
+          const subPath = file.path ? `${file.path}/` : '';
+          const fullPath = `${base}${subPath}${file.hash}${file.ext}`;
 
           ossClient.delete(fullPath, customParams)
             .then((resp) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-provider-upload-oss",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Aliyun OSS provider for strapi upload",
   "homepage": "http://strapi.io",
   "keywords": [


### PR DESCRIPTION
## Problem

Strapi passes a `path` field in the file object when the client calls `/api/upload` with a `path` form-data parameter (e.g. `submission/2026/03/18/document/abc123`). The provider was silently ignoring this field in all three relevant functions, so **all files ended up stored directly under `uploadPath` regardless of the requested sub-directory**.

Additionally, `getFileKey()` (used by `getSignedUrl`) had an operator precedence bug.

## Root Cause

### 1. `upload()` ignores `file.path`

Before (broken) — `file.path` is never used:
```js
const path = config.uploadPath ? `${config.uploadPath}/` : '';
const fullPath = `${path}${file.hash}${file.ext}`;
```

After (fixed):
```js
const base = config.uploadPath ? `${config.uploadPath}/` : '';
const subPath = file.path ? `${file.path}/` : '';
const fullPath = `${base}${subPath}${file.hash}${file.ext}`;
```

### 2. `delete()` ignores `file.path`

Same issue — deletion targeted the wrong OSS key, so deleted files would leave orphan objects in the bucket.

### 3. `getFileKey()` operator precedence bug

Before (broken) — when `uploadPath` is falsy, `config.uploadPath + '/'` evaluates to `'undefined/'` before the `||` is reached:
```js
return `${config.uploadPath + '/' || ''}${path}${file.hash}${file.ext}`;
```

After (fixed):
```js
const base = config.uploadPath ? `${config.uploadPath}/` : '';
return `${base}${subPath}${file.hash}${file.ext}`;
```

## Result

After this fix the OSS object key follows the format that Strapi advertises:

```
{uploadPath}/{file.path}/{hash}{ext}
```

## Testing

Verified locally with Strapi v5 + `pnpm patch` against Aliyun OSS private bucket. Files now appear in the correct sub-directory path.